### PR TITLE
Fix rapidjson bug that gives build error in higher GCC versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,12 @@ if (NOT RAPIDJSONTEST)
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
     )
     file(REMOVE ${RJ_TAR_FILE})
-    execute_process(
-        COMMAND patch -p1 -i ${RJ_PATCH_FILE}
-        WORKING_DIRECTORY ${RJ_DIR}   
-    )
+    if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+        execute_process(
+            COMMAND patch -p1 -i ${RJ_PATCH_FILE}
+            WORKING_DIRECTORY ${RJ_DIR}   
+        )
+    endif()
 endif(NOT RAPIDJSONTEST)
 
 find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,13 +35,19 @@ execute_process(
 find_file(RAPIDJSONTEST NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
 if (NOT RAPIDJSONTEST)
     message("no rapidjson, download")
+    set(RJ_DIR ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/rapidjson-1.1.0)
     set(RJ_TAR_FILE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/v1.1.0.tar.gz)
+    set(RJ_PATCH_FILE ${CMAKE_CURRENT_SOURCE_DIR}/gcc14-fix.patch)
     file(DOWNLOAD https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz ${RJ_TAR_FILE})
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E tar xzf ${RJ_TAR_FILE}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
     )
     file(REMOVE ${RJ_TAR_FILE})
+    execute_process(
+        COMMAND patch -p1 -i ${RJ_PATCH_FILE}
+        WORKING_DIRECTORY ${RJ_DIR}   
+    )
 endif(NOT RAPIDJSONTEST)
 
 find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)

--- a/gcc14-fix.patch
+++ b/gcc14-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/include/rapidjson/document.h b/include/rapidjson/document.h
+index e3e20df..b0f1f70 100644
+--- a/include/rapidjson/document.h
++++ b/include/rapidjson/document.h
+@@ -316,8 +316,6 @@ struct GenericStringRef {
+ 
+     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
+ 
+-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+-
+     //! implicit conversion to plain CharType pointer
+     operator const Ch *() const { return s; }
+ 


### PR DESCRIPTION
First of all, i'd like to start by apologising if i made a mistake. I got strange errors here when compiling OpenAG client... I have no idea how this problem can be "effectively" solved (it makes more sense not to use this PR if there is a another solution). This seems to solve it for now, but maybe it can be done better (it was also mentioned [here](https://github.com/Tencent/rapidjson/pull/719) in 2016).