### PR TITLE
Modernize build for CMake 4 and above

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,22 +1,22 @@
 ---
 AccessModifierOffset: -4
-AlignAfterOpenBracket: true
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
 AlignEscapedNewlines: Left
-AlignOperands: false
+AlignOperands: DontAlign
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
+AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: InlineOnly
-AllowShortIfStatementsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: true
+AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
-BinPackParameters: false
+BinPackParameters: OnePerLine
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Stroustrup
 BreakBeforeInheritanceComma: true
@@ -45,7 +45,6 @@ IncludeCategories:
   - Regex: '.*'
     Priority: 3
 IncludeIsMainRegex: '(_test|_win|_linux|_mac|_ios|_osx|_null)?$'
-IndentCaseLabels: false
 IndentWidth: 4
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false
@@ -61,21 +60,22 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 9999999
 PointerAlignment: Left
-ReflowComments: true
-SortIncludes: false
-SortUsingDeclarations: true
+ReflowComments: Always
+SortIncludes:
+  Enabled: false
+SortUsingDeclarations: Lexicographic
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles: false
+SpacesInAngles: Never
 SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: true
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: Cpp11
+Standard: c++11
 TabWidth: 4
 UseTab: Never
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /build*/
 /.vscode/
-/thirdparty/
 .vs/
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/rapidjson"]
+	path = thirdparty/rapidjson
+	url = https://github.com/Tencent/rapidjson

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,23 @@ if (CLANG_FORMAT_CMD)
     )
 endif(CLANG_FORMAT_CMD)
 
-find_file(RAPIDJSON NAMES rapidjson PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
+macro(get_rapidjson)
+    find_file(RAPIDJSON NAMES rapidjson PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
+endmacro(get_rapidjson)
+get_rapidjson()
 
 if (NOT RAPIDJSON)
-    message(FATAL_ERROR "rapidjson not found.\nyou can pull it with git submodule --update --init --recursive")
+    message("rapidjson not found, pulling submodules")
+    execute_process(
+        COMMAND git submodule update --init --recursive
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif(NOT RAPIDJSON)
+
+get_rapidjson()
+
+if (NOT RAPIDJSON)
+    message(FATAL_ERROR "rapidjson not found after pulling submodules")
 endif(NOT RAPIDJSON)
 
 add_library(rapidjson STATIC IMPORTED ${RAPIDJSON})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.2.0)
+cmake_minimum_required (VERSION 3.10)
 project (DiscordRPC)
 
 include(GNUInstallDirs)
@@ -26,25 +26,11 @@ if (CLANG_FORMAT_CMD)
     )
 endif(CLANG_FORMAT_CMD)
 
-# thirdparty stuff
-execute_process(
-    COMMAND mkdir ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
-    ERROR_QUIET
-)
+find_file(RAPIDJSON NAMES rapidjson PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
 
-find_file(RAPIDJSONTEST NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
-if (NOT RAPIDJSONTEST)
-    message("no rapidjson, download")
-    set(RJ_TAR_FILE ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/v1.1.0.tar.gz)
-    file(DOWNLOAD https://github.com/miloyip/rapidjson/archive/v1.1.0.tar.gz ${RJ_TAR_FILE})
-    execute_process(
-        COMMAND ${CMAKE_COMMAND} -E tar xzf ${RJ_TAR_FILE}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty
-    )
-    file(REMOVE ${RJ_TAR_FILE})
-endif(NOT RAPIDJSONTEST)
-
-find_file(RAPIDJSON NAMES rapidjson rapidjson-1.1.0 PATHS ${CMAKE_CURRENT_SOURCE_DIR}/thirdparty CMAKE_FIND_ROOT_PATH_BOTH)
+if (NOT RAPIDJSON)
+    message(FATAL_ERROR "rapidjson not found.\nyou can pull it with git submodule --update --init --recursive")
+endif(NOT RAPIDJSON)
 
 add_library(rapidjson STATIC IMPORTED ${RAPIDJSON})
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ There's a [CMake](https://cmake.org/download/) file that should be able to gener
 
 ```sh
     cd <path to discord-rpc>
+    git submodule update --init --recursive
     mkdir build
     cd build
     cmake .. -DCMAKE_INSTALL_PREFIX=<path to install discord-rpc to>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 include_directories(${PROJECT_SOURCE_DIR}/include)
+include_directories(${RAPIDJSON}/include)
 
 option(ENABLE_IO_THREAD "Start up a separate I/O thread, otherwise I'd need to call an update function" ON)
 option(USE_STATIC_CRT "Use /MT[d] for dynamic library" OFF)

--- a/src/discord_register_linux.cpp
+++ b/src/discord_register_linux.cpp
@@ -42,12 +42,12 @@ extern "C" DISCORD_EXPORT void Discord_Register(const char* applicationId, const
     }
 
     const char* desktopFileFormat = "[Desktop Entry]\n"
-                                   "Name=Game %s\n"
-                                   "Exec=%s %%u\n" // note: it really wants that %u in there
-                                   "Type=Application\n"
-                                   "NoDisplay=true\n"
-                                   "Categories=Discord;Games;\n"
-                                   "MimeType=x-scheme-handler/discord-%s;\n";
+                                    "Name=Game %s\n"
+                                    "Exec=%s %%u\n" // note: it really wants that %u in there
+                                    "Type=Application\n"
+                                    "NoDisplay=true\n"
+                                    "Categories=Discord;Games;\n"
+                                    "MimeType=x-scheme-handler/discord-%s;\n";
     char desktopFile[2048];
     int fileLen = snprintf(
       desktopFile, sizeof(desktopFile), desktopFileFormat, applicationId, command, applicationId);

--- a/src/serialization.cpp
+++ b/src/serialization.cpp
@@ -152,8 +152,7 @@ size_t JsonWriteRichPresenceObj(char* dest,
                     WriteOptionalString(writer, "join", presence->joinSecret);
                     WriteOptionalString(writer, "spectate", presence->spectateSecret);
                 }
-                else 
-                {
+                else {
                     bool btn1 = presence->buttonUrl[0] && presence->buttonLabel[0];
                     bool btn2 = presence->buttonUrl[1] && presence->buttonLabel[1];
                     if (btn1 || btn2) {


### PR DESCRIPTION
This PR will:
- Update the minimum required version of CMake to be `3.10`. This has no side effects and allows for compilation on CMake 4.
- `thirdparty/rapidjson` is now a submodule that points to `master`. This has no side effects, and fixes compilation bugs on newer versions of GCC [#2]. The commit may need to be pinned to preserve compatbility, but the rapidjson project seems to be in maintenance for the last couple of years.
- Updates to `.clang-format` to be parseable by recent versions of clang-format

These changes allow for clean compilation of discord-rpc on CMake 4 and above, with no extra setup or patches required.